### PR TITLE
Fix `ObjectEnum.asPairs` behaving incorrectly.

### DIFF
--- a/fusion_util/enums.py
+++ b/fusion_util/enums.py
@@ -71,7 +71,12 @@ class Enum(object):
         values = (EnumItem(value, desc) for value, desc in pairs)
         return cls(doc=doc, values=values)
 
-    fromPairs = from_pairs
+
+    @classmethod
+    def fromPairs(cls, doc, pairs):
+        warn('Enum.fromPairs is deprecated, use Enum.from_pairs',
+             DeprecationWarning, 2)
+        return cls.from_pairs(doc, pairs)
 
 
     def get(self, value):
@@ -101,10 +106,14 @@ class Enum(object):
         except InvalidEnumItem:
             return u''
 
-    getDesc = desc
+
+    def getDesc(self, value):
+        warn('Enum.getDesc is deprecated, use Enum.desc',
+             DeprecationWarning, 2)
+        return self.desc(value)
 
 
-    def get_extra(self, value, extra_name, default=None):
+    def extra(self, value, extra_name, default=None):
         """
         Get the additional enumeration value for ``extra_name``.
 
@@ -117,7 +126,11 @@ class Enum(object):
         except InvalidEnumItem:
             return default
 
-    getExtra = get_extra
+
+    def getExtra(self, value, extraName, default=None):
+        warn('Enum.getExtra is deprecated, use Enum.extra',
+             DeprecationWarning, 2)
+        return self.extra(value, extraName, default)
 
 
     def find(self, **names):
@@ -148,7 +161,11 @@ class Enum(object):
             if item.get(name) == value:
                 yield item
 
-    findAll = find_all
+
+    def findAll(self, **names):
+        warn('Enum.findAll is deprecated, use Enum.find_all',
+             DeprecationWarning, 2)
+        return self.find_all(**names)
 
 
     def as_pairs(self):
@@ -160,7 +177,11 @@ class Enum(object):
         """
         return [(i.value, i.desc) for i in self]
 
-    asPairs = as_pairs
+
+    def asPairs(self):
+        warn('Enum.asPairs is deprecated, use Enum.as_pairs',
+             DeprecationWarning, 2)
+        return self.as_pairs()
 
 
 

--- a/fusion_util/test/test_enums.py
+++ b/fusion_util/test/test_enums.py
@@ -45,7 +45,7 @@ class Warnings(object):
 
 
 
-def deprecated(message):
+def is_deprecated(message):
     """
     Make a matcher that checks that a callable produces exactly one
     `DeprecationWarning`.
@@ -118,7 +118,7 @@ class EnumItemTests(TestCase):
         item = EnumItem(u'foo', u'Foo', a=1)
         self.assertThat(
             lambda: item.a,
-            deprecated(Contains('use EnumItem.get')))
+            is_deprecated(Contains('use EnumItem.get')))
 
 
 
@@ -234,7 +234,7 @@ class GenericEnumTestsMixin(TestCase):
         enum = Enum('doc', [])
         self.assertThat(
             lambda: enum.findAll(foo=u'a'),
-            deprecated(Contains('use Enum.find_all')))
+            is_deprecated(Contains('use Enum.find_all')))
 
 
     def test_getDesc_deprecated(self):
@@ -244,7 +244,7 @@ class GenericEnumTestsMixin(TestCase):
         enum = Enum('doc', [])
         self.assertThat(
             lambda: enum.getDesc(u'a'),
-            deprecated(Contains('use Enum.desc')))
+            is_deprecated(Contains('use Enum.desc')))
 
 
     def test_getExtra_deprecated(self):
@@ -254,7 +254,7 @@ class GenericEnumTestsMixin(TestCase):
         enum = Enum('doc', [])
         self.assertThat(
             lambda: enum.getExtra(u'a', u'extra'),
-            deprecated(Contains('use Enum.extra')))
+            is_deprecated(Contains('use Enum.extra')))
 
 
     def test_asPairs_deprecated(self):
@@ -264,7 +264,7 @@ class GenericEnumTestsMixin(TestCase):
         enum = Enum('doc', [])
         self.assertThat(
             lambda: enum.asPairs(),
-            deprecated(Contains('use Enum.as_pairs')))
+            is_deprecated(Contains('use Enum.as_pairs')))
 
 
     def test_fromPairs_deprecated(self):
@@ -273,7 +273,7 @@ class GenericEnumTestsMixin(TestCase):
         """
         self.assertThat(
             lambda: Enum.fromPairs('doc', []),
-            deprecated(Contains('use Enum.from_pairs')))
+            is_deprecated(Contains('use Enum.from_pairs')))
 
 
 

--- a/fusion_util/test/test_enums.py
+++ b/fusion_util/test/test_enums.py
@@ -41,7 +41,8 @@ class Warnings(object):
 
 
     def __str__(self):
-        return 'Warnings()'
+        return 'Warnings({})'.format(
+            str(self.warnings_matcher))
 
 
 

--- a/fusion_util/test/test_enums.py
+++ b/fusion_util/test/test_enums.py
@@ -41,8 +41,7 @@ class Warnings(object):
 
 
     def __str__(self):
-        return 'Warnings({})'.format(
-            str(self.warnings_matcher))
+        return 'Warnings({!s})'.format(self.warnings_matcher)
 
 
 

--- a/fusion_util/test/test_enums.py
+++ b/fusion_util/test/test_enums.py
@@ -5,10 +5,60 @@ from testtools import TestCase
 from testtools.matchers import AfterPreprocessing as After
 from testtools.matchers import (
     Contains, Equals, HasLength, Is, MatchesAll, MatchesListwise,
-    MatchesStructure, raises)
+    MatchesStructure, Mismatch, raises)
 
 from fusion_util.enums import Enum, EnumItem, filter_enum, ObjectEnum
 from fusion_util.errors import InvalidEnumItem
+
+
+
+class Warnings(object):
+    """
+    Match if the matchee produces deprecation warnings.
+    """
+    def __init__(self, warnings_matcher=None):
+        """
+        Create a Warnings matcher.
+
+        :param warnings_matcher: Optional validator for the warnings emitted by
+        matchee. If no warnings_matcher is supplied then the simple fact that
+        at least one warning is emitted is considered enough to match on.
+        """
+        self.warnings_matcher = warnings_matcher
+
+
+    def match(self, matchee):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            matchee()
+            if not w:
+                mismatch = Mismatch('Expected warnings, got none')
+            elif self.warnings_matcher:
+                mismatch = self.warnings_matcher.match(w)
+            else:
+                mismatch = None
+            return mismatch
+
+
+    def __str__(self):
+        return 'Warnings()'
+
+
+
+def deprecated(message):
+    """
+    Make a matcher that checks that a callable produces exactly one
+    `DeprecationWarning`.
+
+    :param message: Matcher for the warning message.
+    """
+    return Warnings(
+        MatchesListwise([
+            MatchesStructure(
+                category=Is(DeprecationWarning),
+                message=After(
+                    str,
+                    message))]))
 
 
 
@@ -66,17 +116,9 @@ class EnumItemTests(TestCase):
         `EnumItem.__getattr__` is deprecated.
         """
         item = EnumItem(u'foo', u'Foo', a=1)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            item.a
-            self.assertThat(
-                w,
-                MatchesListwise([
-                    MatchesStructure(
-                        category=Is(DeprecationWarning),
-                        message=After(
-                            str,
-                            Contains('use EnumItem.get')))]))
+        self.assertThat(
+            lambda: item.a,
+            deprecated(Contains('use EnumItem.get')))
 
 
 
@@ -185,6 +227,55 @@ class GenericEnumTestsMixin(TestCase):
             raises(ValueError))
 
 
+    def test_findAll_deprecated(self):
+        """
+        `Enum.findAll` is deprecated.
+        """
+        enum = Enum('doc', [])
+        self.assertThat(
+            lambda: enum.findAll(foo=u'a'),
+            deprecated(Contains('use Enum.find_all')))
+
+
+    def test_getDesc_deprecated(self):
+        """
+        `Enum.getDesc` is deprecated.
+        """
+        enum = Enum('doc', [])
+        self.assertThat(
+            lambda: enum.getDesc(u'a'),
+            deprecated(Contains('use Enum.desc')))
+
+
+    def test_getExtra_deprecated(self):
+        """
+        `Enum.getExtra` is deprecated.
+        """
+        enum = Enum('doc', [])
+        self.assertThat(
+            lambda: enum.getExtra(u'a', u'extra'),
+            deprecated(Contains('use Enum.extra')))
+
+
+    def test_asPairs_deprecated(self):
+        """
+        `Enum.asPairs` is deprecated.
+        """
+        enum = Enum('doc', [])
+        self.assertThat(
+            lambda: enum.asPairs(),
+            deprecated(Contains('use Enum.as_pairs')))
+
+
+    def test_fromPairs_deprecated(self):
+        """
+        `Enum.fromPairs` is deprecated.
+        """
+        self.assertThat(
+            lambda: Enum.fromPairs('doc', []),
+            deprecated(Contains('use Enum.from_pairs')))
+
+
 
 def enum_values_fixture():
     """
@@ -234,19 +325,19 @@ class EnumTests(TestCase):
         """
         enum = Enum('doc', enum_values_fixture())
         self.assertThat(
-            enum.get_extra(u'foo', 'quux'),
+            enum.extra(u'foo', 'quux'),
             Equals(u'hello'))
         self.assertThat(
-            enum.get_extra(u'foo', 'frob'),
+            enum.extra(u'foo', 'frob'),
             Equals(u'world'))
         self.assertThat(
-            enum.get_extra(u'bar', 'quux'),
+            enum.extra(u'bar', 'quux'),
             Equals(u'goodbye'))
         self.assertThat(
-            enum.get_extra(u'bar', 'nope'),
+            enum.extra(u'bar', 'nope'),
             Is(None))
         self.assertThat(
-            enum.get_extra(u'bar', 'nope', u''),
+            enum.extra(u'bar', 'nope', u''),
             Equals(u''))
 
 
@@ -402,19 +493,19 @@ class ObjectEnumTests(TestCase):
         values = object_enum_values_fixture(object1, object2, object3)
         enum = ObjectEnum('doc', values)
         self.assertThat(
-            enum.get_extra(object1, 'quux'),
+            enum.extra(object1, 'quux'),
             Equals(u'hello'))
         self.assertThat(
-            enum.get_extra(object1, 'frob'),
+            enum.extra(object1, 'frob'),
             Equals(u'world'))
         self.assertThat(
-            enum.get_extra(object2, 'quux'),
+            enum.extra(object2, 'quux'),
             Equals(u'goodbye'))
         self.assertThat(
-            enum.get_extra(u'bar', 'nope'),
+            enum.extra(u'bar', 'nope'),
             Is(None))
         self.assertThat(
-            enum.get_extra(u'bar', 'nope', u''),
+            enum.extra(u'bar', 'nope', u''),
             Equals(u''))
 
 


### PR DESCRIPTION
Also emit deprecating warnings for all the old camelcase methods.

Fixes #4.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/fusionapp/fusion-util/5)

<!-- Reviewable:end -->
